### PR TITLE
[Comment Feature] - Implement Facebook auth from comment section #5

### DIFF
--- a/lib/features/Comment/presentation/widgets/comment_section_widget.dart
+++ b/lib/features/Comment/presentation/widgets/comment_section_widget.dart
@@ -79,27 +79,30 @@ class CommentSectionWidget extends StatelessWidget {
                 ),
               ),
             ),
-            Builder(builder: (context) {
-              if (serviceLocator<AuthCubit>().state.user == null) {
-                return SizedBox(
-                  width: double.infinity,
-                  child: FilledButton(
-                    onPressed: () {
-                      
-                    },
-                    child: const Text('Login to Comment'),
-                  ),
-                );
-              }
-              return CommentField(
-                onSubmit: (comment) {
-                  BlocProvider.of<CommentCubit>(context).createComment(
-                    roomID: roomID,
-                    comment: comment,
+            BlocBuilder<AuthCubit, AuthState>(
+              bloc: serviceLocator<AuthCubit>(),
+              builder: (context, state) {
+                if (state.user == null) {
+                  return SizedBox(
+                    width: double.infinity,
+                    child: FilledButton(
+                      onPressed: () {
+                        serviceLocator<AuthCubit>().login();
+                      },
+                      child: const Text('Login to Comment'),
+                    ),
                   );
-                },
-              );
-            }),
+                }
+                return CommentField(
+                  onSubmit: (comment) {
+                    BlocProvider.of<CommentCubit>(context).createComment(
+                      roomID: roomID,
+                      comment: comment,
+                    );
+                  },
+                );
+              },
+            ),
             VerticalSpacers.small,
           ],
         ),

--- a/lib/features/LiveStream/presentation/pages/live_stream_page.dart
+++ b/lib/features/LiveStream/presentation/pages/live_stream_page.dart
@@ -44,7 +44,9 @@ class _LiveStreamPageState extends State<LiveStreamPage> {
     return BlocListener<AuthCubit, AuthState>(
       bloc: GetIt.instance<AuthCubit>(),
       listener: (context, state) {
-        if (state.status == LoginStatus.success) {
+        final liveStreamState = serviceLocator<LiveStreamBloc>().state;
+        if (state.status == LoginStatus.success &&
+            liveStreamState is LivestreamInitial) {
           GetIt.instance<LiveStreamBloc>().add(
             CreateRoomEvent(user: state.user!),
           );


### PR DESCRIPTION
- issue #5 
---
- CommentSectionWidget
  - call login event when login button is clicked
  - wrap login button and comment field in a auth bloc builder
    - show comment field when authenticated, show login button otherwise
- LiveStreamPage
  - call CreateRoomEvent only when user logs in and livestream state is not ready (initial) 